### PR TITLE
Fix: Sanitize artifactId + Validate groupId + Test Coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'io.github.grafx1.scaffolder'
-version = '2.1.0'
+version = '2.1.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/github/grafx1/scaffolder/utils/PackageNameUtil.java
+++ b/src/main/java/io/github/grafx1/scaffolder/utils/PackageNameUtil.java
@@ -1,0 +1,24 @@
+package io.github.grafx1.scaffolder.utils;
+
+public class PackageNameUtil {
+
+    private static final String PACKAGE_PART_REGEX = "^[a-zA-Z][a-zA-Z0-9]*$";
+
+    public static String computeBasePackage(String groupId, String artifactId, String entityName) {
+        validateGroupId(groupId);
+
+        String sanitizedArtifactId = artifactId.replace("-", "_"); // on continue de normaliser ici
+        String sanitizedEntity = entityName.substring(0, 1).toLowerCase() + entityName.substring(1);
+
+        return String.join(".", groupId, sanitizedArtifactId, sanitizedEntity, entityName);
+    }
+
+    public static void validateGroupId(String groupId) {
+        String[] parts = groupId.split("\\.");
+        for (String part : parts) {
+            if (!part.matches(PACKAGE_PART_REGEX)) {
+                throw new IllegalArgumentException("Invalid groupId part: '" + part + "' — each part must match [a-zA-Z][a-zA-Z0-9]*");
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/grafx1/scaffolder/utils/Tools.java
+++ b/src/main/java/io/github/grafx1/scaffolder/utils/Tools.java
@@ -10,6 +10,8 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.github.grafx1.scaffolder.utils.PackageNameUtil.computeBasePackage;
+
 public class Tools {
 
     /**
@@ -32,24 +34,6 @@ public class Tools {
      * Red hexadecimal code color
      */
     public static final String RED = "\u001B[31m";
-
-    /**
-     * String Utils for capitalize the first char of string
-     * @param str
-     * @return
-     */
-    public static String capitalize(String str) {
-        return str.substring(0, 1).toUpperCase() + str.substring(1);
-    }
-
-    /**
-     * String utils, lower case the first char of a string
-     * @param word
-     * @return
-     */
-    private static String camelCase(String word) {
-        return word.substring(0, 1).toLowerCase() + word.substring(1);
-    }
 
     /**
      * Extract groupId and artefactId from pom file
@@ -116,8 +100,7 @@ public class Tools {
         } catch (IOException e) {
             System.err.println("Impossible de lire les métadonnées du projet");
         }
-
-        return group + "." + appName + "." + camelCase(entityName) + "." + capitalize(entityName);
+        return computeBasePackage(group, appName, entityName);
     }
 
     /**
@@ -126,7 +109,7 @@ public class Tools {
     public static void printHelp() {
         System.out.println(GREEN + "\n *** Spring Boot Scaffolder Plugin - Help & Hype ***" + RESET);
         System.out.println(GREEN + "--------------------------------------------------" + RESET);
-        System.out.println(GREEN + "👷 What does it do?" + RESET);
+        System.out.println(GREEN + " What does it do?" + RESET);
         System.out.println(GREEN + "  Automatically generates boilerplate Spring Boot code" + RESET);
         System.out.println(GREEN + "  for Entities, DTOs, Services, Controllers, Repositories, etc." + RESET);
         System.out.println(GREEN + "\n-> Usage:" + RESET);

--- a/src/main/resources/templates/ControllerTemplate.java.ftl
+++ b/src/main/resources/templates/ControllerTemplate.java.ftl
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-
+import ${basePackage}.dto.PagedResponse;
 import ${packageName}.dto.${className}Dto;
 import ${packageName}.service.${className}Service;
 
@@ -23,8 +23,8 @@ public class ${className}Controller {
     }
 
     @GetMapping
-    public ResponseEntity<?> findAll(@RequestParam String searchTerm, Pageable pageable) {
-        return ResponseEntity.ok(service.findAll(searchTerm, pageable));
+    public ResponseEntity<PagedResponse<${className}Dto>> findAll(@RequestParam(defaultValue = "") String term,Pageable pageable ) {
+        return ResponseEntity.ok(service.findAll(term, pageable));
     }
 
     @PutMapping("/{id}")

--- a/src/main/resources/templates/MapperTemplate.java.ftl
+++ b/src/main/resources/templates/MapperTemplate.java.ftl
@@ -17,10 +17,13 @@ import java.util.List;
 public interface ${className}Mapper {
     ${className}Mapper INSTANCE = Mappers.getMapper(${className}Mapper.class);
 
+
     ${className}Dto toDto(${className}Entity entity);
+    @Mapping(target = "version", ignore = true)
     ${className}Entity toEntity(${className}Dto dto);
 
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "version", ignore = true)
     void updateEntityFromDto(${className}Dto dto, @MappingTarget ${className}Entity entity);
 
     List<${className}Dto> toDtoList(List<${className}Entity> entities);

--- a/src/main/resources/templates/PagedResponseTemplate.java.ftl
+++ b/src/main/resources/templates/PagedResponseTemplate.java.ftl
@@ -1,0 +1,24 @@
+package ${packageName}.dto;
+
+import org.springframework.data.domain.Page;
+import java.util.List;
+
+public record PagedResponse<T>(
+    List<T> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean last
+) {
+    public static <T> PagedResponse<T> from(Page<T> page) {
+        return new PagedResponse<>(
+        page.getContent(),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages(),
+        page.isLast()
+        );
+    }
+}

--- a/src/main/resources/templates/ServiceImplTemplate.java.ftl
+++ b/src/main/resources/templates/ServiceImplTemplate.java.ftl
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-
+import ${basePackage}.dto.PagedResponse;
 import ${packageName}.dto.${className}Dto;
 import ${packageName}.service.${className}Service;
 import ${packageName}.entity.${className}Entity;
@@ -34,8 +34,9 @@ public class ${className}ServiceImpl implements ${className}Service {
     }
 
     @Override
-    public Page<${className}Dto> findAll(String term, Pageable pageable) {
-        return mapper.toDtoPage(repository.findAll(term, pageable));
+    public PagedResponse<${className}Dto> findAll(String term, Pageable pageable) {
+        Page<${className}Entity> page = repository.findAll(term, pageable);
+        return PagedResponse.from(page.map(mapper::toDto));
     }
 
     @Override

--- a/src/main/resources/templates/ServiceTemplate.java.ftl
+++ b/src/main/resources/templates/ServiceTemplate.java.ftl
@@ -1,6 +1,6 @@
 package ${packageName}.service;
 
-import org.springframework.data.domain.Page;
+import ${basePackage}.dto.PagedResponse;
 import org.springframework.data.domain.Pageable;
 
 import ${packageName}.dto.${className}Dto;
@@ -9,7 +9,7 @@ public interface ${className}Service {
 
     ${className}Dto save(${className}Dto dto);
     ${className}Dto find(String id);
-    Page<${className}Dto> findAll(String term, Pageable pageable);
+    PagedResponse<${className}Dto> findAll(String term, Pageable pageable);
     ${className}Dto update(String id, ${className}Dto dto);
     void delete(String id);
 

--- a/src/main/resources/templates/test/ControllerTemplateTest.java.ftl
+++ b/src/main/resources/templates/test/ControllerTemplateTest.java.ftl
@@ -1,5 +1,6 @@
 package ${packageName}.controller;
 
+import ${basePackage}.dto.PagedResponse;
 import ${packageName}.dto.${className}Dto;
 import ${packageName}.service.${className}Service;
 
@@ -95,15 +96,18 @@ class ${className}ControllerTest {
 
     @Test
     void shouldReturnPagedList() throws Exception {
-        Page<${className}Dto> page = new PageImpl<>(List.of(buildDto()));
-        when(service.findAll(anyString(), any(Pageable.class))).thenReturn(page);
+    Page<${className}Dto> page = new PageImpl<>(List.of(buildDto()));
+        PagedResponse<${className}Dto> response = PagedResponse.from(page);
+
+        when(service.findAll(anyString(), any())).thenReturn(response);
 
         mockMvc.perform(get("/api/${classNameLower}s")
-            .param("searchTerm", "keyword")
-            .param("page", "0")
-            .param("size", "10"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.content", hasSize(1)));
+        .param("term", "test")
+        .param("page", "0")
+        .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     private ${className}Dto buildDto() {

--- a/src/main/resources/templates/test/ServiceTemplateTest.java.ftl
+++ b/src/main/resources/templates/test/ServiceTemplateTest.java.ftl
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import ${basePackage}.dto.PagedResponse;
 import ${packageName}.dto.${className}Dto;
 import ${packageName}.entity.${className}Entity;
 import ${packageName}.mapper.${className}Mapper;
@@ -77,18 +78,15 @@ class ${className}ServiceTest {
     }
 
     @Test
-    void shouldReturnPagedDtos() {
-        Pageable pageable = PageRequest.of(0, 10);
-        List<${className}Entity> entities = List.of(buildEntity());
-        Page<${className}Entity> page = new PageImpl<>(entities, pageable, 1);
-        Page<${className}Dto> mappedPage = new PageImpl<>(List.of(buildDto()), pageable, 1);
+    void shouldReturnPagedResult() {
+    Page<${className}Entity> entityPage = new PageImpl<>(List.of(new ${className}Entity()));
+        Page<${className}Dto> dtoPage = new PageImpl<>(List.of(buildDto()));
+        when(repository.findAll(anyString(), any())).thenReturn(entityPage);
+        when(mapper.toDto(any(${className}Entity.class))).thenReturn(buildDto());
 
-        when(repository.findAll(anyString(), eq(pageable))).thenReturn(page);
-        when(mapper.toDtoPage(page)).thenReturn(mappedPage);
+        PagedResponse<${className}Dto> result = service.findAll("search", Pageable.ofSize(10));
 
-        Page<${className}Dto> result = service.findAll("test", pageable);
-
-        assertThat(result).hasSize(1);
+        assertThat(result.content()).hasSize(1);
     }
 
     @Test

--- a/src/test/java/io/github/grafx1/scaffolder/GeneratorServiceTest.java
+++ b/src/test/java/io/github/grafx1/scaffolder/GeneratorServiceTest.java
@@ -2,51 +2,64 @@ package io.github.grafx1.scaffolder;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.file.*;
-import java.io.*;
-import java.util.List;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GeneratorServiceTest {
 
     private GeneratorService generatorService;
+    private Path testBaseDir;
 
     @BeforeEach
     void setUp() {
         generatorService = new GeneratorService();
+        testBaseDir = Paths.get("build/test-output");
+    }
+
+
+    @Test
+    void testGenerateStructureWithValidEntity() {
+        assertDoesNotThrow(() -> generatorService.generateStructure("User", testBaseDir, false));
     }
 
     @Test
-    void testGenerateAll_shouldCreateAllExpectedFiles(@TempDir Path tempDir) throws IOException {
-        // GIVEN
-        String fqcn = "com.example.test.user.User";
+    void testGenerateStructureWithMultipleValidEntities() {
+        assertDoesNotThrow(() -> generatorService.generateStructure("User,Product,Order", testBaseDir, true));
+    }
 
-        // WHEN
-        generatorService.generateAll(fqcn, tempDir, true);
+    @Test
+    void testGenerateStructureWithInvalidEntityNameThrowsException() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                generatorService.generateStructure("com.example.User", testBaseDir, false));
+        assertEquals("Invalid entity name : com.example.User", exception.getMessage());
+    }
 
-        // THEN
-        List<String> expectedFiles = List.of(
-                "user/entity/UserEntity.java",
-                "user/dto/UserDto.java",
-                "user/repository/UserRepository.java",
-                "user/service/UserService.java",
-                "user/service/impl/UserServiceImpl.java",
-                "user/controller/UserController.java",
-                "user/mapper/UserMapper.java"
-        );
+    @Test
+    void testGenerateAllCreatesExpectedFiles() {
+        generatorService.generateAll("com.example.demo.User", testBaseDir, true);
 
-        for (String relPath : expectedFiles) {
-            Path filePath = tempDir.resolve("src/main/java/com/example/test").resolve(relPath);
-            assertThat(Files.exists(filePath))
-                    .withFailMessage("Expected file does not exist: " + filePath)
-                    .isTrue();
+        Path expectedEntityPath = testBaseDir.resolve("src/main/java/com/example/demo/entity/UserEntity.java");
+        assertTrue(expectedEntityPath.toFile().exists(), "Entity file should be generated");
 
-            // Vérifie que le fichier contient au moins le nom de la classe
-            String content = Files.readString(filePath);
-            assertThat(content).contains("User");
+        Path expectedTestPath = testBaseDir.resolve("src/test/java/com/example/demo/mapper/UserMapperTest.java");
+        assertTrue(expectedTestPath.toFile().exists(), "Mapper test file should be generated");
+    }
+
+    @Test
+    void testPagedResponseGeneratedOnce() {
+        Path pagedResponsePath = testBaseDir.resolve("src/main/java/com/example/dto/PagedResponse.java");
+        if (pagedResponsePath.toFile().exists()) {
+            pagedResponsePath.toFile().delete();
         }
+
+        generatorService.generateAll("com.example.demo.Customer", testBaseDir, false);
+        assertTrue(pagedResponsePath.toFile().exists(), "PagedResponse.java should be generated");
+
+        long lastModified = pagedResponsePath.toFile().lastModified();
+        generatorService.generateAll("com.example.demo.Client", testBaseDir, false);
+        assertEquals(lastModified, pagedResponsePath.toFile().lastModified(), "PagedResponse.java should not be regenerated");
     }
 }

--- a/src/test/java/io/github/grafx1/scaffolder/utils/PackageNameUtilTest.java
+++ b/src/test/java/io/github/grafx1/scaffolder/utils/PackageNameUtilTest.java
@@ -1,0 +1,36 @@
+package io.github.grafx1.scaffolder.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PackageNameUtilTest {
+
+    @Test
+    void shouldSanitizeArtifactIdWithDashes() {
+        // GIVEN
+        String groupId = "com.example";
+        String artifactId = "my-project";
+        String entity = "CustomerMerchant";
+
+        // WHEN
+        String packageName = PackageNameUtil.computeBasePackage(groupId, artifactId, entity);
+
+        // THEN
+        System.out.println(packageName);
+        assertThat(packageName)
+                .isEqualTo("com.example.my_project.customerMerchant.CustomerMerchant")
+                .doesNotContain("-")
+                .startsWith("com.example.my_project");
+    }
+
+    @Test
+    void shouldFailOnInvalidGroupId() {
+        assertThatThrownBy(() -> PackageNameUtil.validateGroupId("com.example_123"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid groupId part");
+    }
+
+}

--- a/src/test/java/io/github/grafx1/scaffolder/utils/ToolsTest.java
+++ b/src/test/java/io/github/grafx1/scaffolder/utils/ToolsTest.java
@@ -1,0 +1,84 @@
+package io.github.grafx1.scaffolder.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolsTest {
+
+    @Test
+    void testExtractPomInfoWithValidPom() {
+        String pom = """
+                    <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.example</groupId>
+                      <artifactId>demo-app</artifactId>
+                    </project>
+                """;
+
+        Map<String, String> info = Tools.extractPomInfo(pom);
+        assertEquals("com.example", info.get("groupId"));
+        assertEquals("demo-app", info.get("artifactId"));
+    }
+
+    @Test
+    void testExtractPomInfoWithoutGroupAndArtifact() {
+        String pom = "<project><version>1.0.0</version></project>";
+
+        Map<String, String> info = Tools.extractPomInfo(pom);
+        assertEquals("com.unknown", info.get("groupId"));
+        assertEquals("app", info.get("artifactId"));
+    }
+
+    @Test
+    void testPrintHelpPrintsToConsole() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        Tools.printHelp();
+
+        String output = out.toString();
+        assertTrue(output.contains("Spring Boot Scaffolder Plugin"));
+        System.setOut(System.out); // Reset
+    }
+
+    @Test
+    void testPrintFooterWithTests() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        Tools.printFooter("com.example.User", true, "/tmp/project");
+
+        String output = out.toString();
+        assertTrue(output.contains("With tests"));
+        assertTrue(output.contains("Yes"));
+        System.setOut(System.out);
+    }
+
+    @Test
+    void testComputeFQCNFromProjectWithDefaultsWhenNoFiles() {
+        Path fakeDir = Paths.get("non-existent-dir");
+        String fqcn = Tools.computeFQCNFromProject(fakeDir, "User");
+        System.out.println(fqcn);
+        assertTrue(fqcn.endsWith(".User"));
+    }
+
+    @Test
+    void testPrintHeader() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out));
+
+        Tools.printHeader();
+
+        String output = out.toString();
+        assertTrue(output.contains("SPRING BOOT SCAFFOLDER PLUGIN"));
+        System.setOut(System.out);
+    }
+}


### PR DESCRIPTION
This PR 

- fixes a critical bug that prevented valid Java packages from being generated when the `artifactId `contained hyphens (`-`).
- It also introduces strict `groupId `validation, in accordance with Java package naming conventions.
- Finally, unit tests have been added to ensure the robustness of this logic.
