### PR TITLE
Enokdev/cli

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,518 @@
+# 🧰 Spring Boot Scaffolder - Guide d'utilisation complet
+
+Spring Boot Scaffolder est un outil puissant qui génère automatiquement la structure de code pour des applications Spring Boot en utilisant une architecture orientée domaine. Cette documentation présente toutes les fonctionnalités disponibles et comment les utiliser efficacement.
+
+## 📋 Table des matières
+
+1. [Structure générée](#structure-générée)
+2. [Prérequis](#prérequis)
+3. [Installation et configuration](#installation-et-configuration)
+4. [Utilisation de la ligne de commande (CLI)](#utilisation-de-la-ligne-de-commande-cli)
+5. [Génération sélective de composants](#génération-sélective-de-composants)
+6. [Mode interactif](#mode-interactif)
+7. [Personnalisation des templates](#personnalisation-des-templates)
+8. [Bonnes pratiques](#bonnes-pratiques)
+9. [Résolution de problèmes](#résolution-de-problèmes)
+10. [Test de la bibliothèque en local](#test-de-la-bibliothèque-en-local)
+11. [Contribuer au projet](#contribuer-au-projet)
+
+## Structure générée
+
+Spring Boot Scaffolder génère une structure orientée domaine comme celle-ci :
+
+```
+📂com
+  📂 example
+    📂 myapplication
+        - MyApplication.java
+        |
+        📂 customer
+        |  📂 entity
+        |     - CustomerEntity.java
+        |  📂 controller
+        |      - CustomerController.java
+        |  📂 service
+        |      📂 impl
+        |         - CustomerServiceImpl.java
+        |       - CustomerService.java
+        |  📂 repository
+        |      - CustomerRepository.java
+        |  📂 dto
+        |      - CustomerDto.java
+        |  📂 mapper
+        |      - CustomerMapper.java
+```
+
+Les composants suivants sont générés pour chaque entité :
+- **Entity** : Classe JPA avec annotations
+- **DTO** : Objet de transfert de données
+- **Repository** : Interface Spring Data JPA
+- **Service** : Interface définissant les opérations métier
+- **ServiceImpl** : Implémentation concrète du service
+- **Controller** : Endpoints REST
+- **Mapper** : Conversion entre Entity et DTO (avec MapStruct)
+
+## Prérequis
+
+### Pour Gradle
+
+```groovy
+dependencies {
+    // Spring Boot et Spring Data JPA sont requis
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    
+    // Support pour Java Record, Optional, Stream et types temporels
+    implementation 'com.fasterxml.jackson.module:jackson-module-parameter-names'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // MapStruct pour le mapping Entity <-> DTO
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    // Lombok (optionnel mais recommandé)
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+}
+```
+
+### Pour Maven
+
+```xml
+<properties>
+    <org.mapstruct.version>1.6.3</org.mapstruct.version>
+</properties>
+
+<dependencies>
+    <!-- Spring Boot et Spring Data JPA -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    
+    <!-- Lombok -->
+    <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <optional>true</optional>
+    </dependency>
+
+    <!-- MapStruct -->
+    <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct</artifactId>
+        <version>${org.mapstruct.version}</version>
+    </dependency>
+    
+    <!-- Support pour Java Record, Optional, Stream et types temporels -->
+    <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-parameter-names</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.11.0</version>
+            <configuration>
+                <source>17</source> <!-- Ajustez selon votre version de Java -->
+                <target>17</target> <!-- Ajustez selon votre version de Java -->
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.mapstruct</groupId>
+                        <artifactId>mapstruct-processor</artifactId>
+                        <version>${org.mapstruct.version}</version>
+                    </path>
+                    <path>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>${lombok.version}</version>
+                    </path>
+                    <path>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok-mapstruct-binding</artifactId>
+                        <version>0.2.0</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+## Installation et configuration
+
+### Avec Gradle
+
+```groovy
+// Dans votre build.gradle
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "io.github.grafx1.scaffolder:spring-boot-scaffolder:2.1.1"
+  }
+}
+
+apply plugin: 'io.github.grafx1.scaffolder'
+```
+
+### Avec Maven
+
+```xml
+<!-- Dans votre pom.xml -->
+<dependency>
+  <groupId>io.github.grafx1.scaffolder</groupId>
+  <artifactId>spring-boot-scaffolder</artifactId>
+  <version>2.1.1</version>
+</dependency>
+
+<plugin>
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>exec-maven-plugin</artifactId>
+  <version>3.1.0</version>
+  <executions>
+    <execution>
+      <id>scaffold</id>
+      <phase>none</phase> <!-- Exécution manuelle -->
+      <goals><goal>java</goal></goals>
+    </execution>
+  </executions>
+  <configuration>
+    <mainClass>io.github.grafx1.scaffolder.cli.SpringBootScaffolderCLI</mainClass>
+    <classpathScope>runtime</classpathScope>
+    <arguments>
+      <argument>${entityName}</argument>
+      <argument>${withTests}</argument>
+    </arguments>
+  </configuration>
+</plugin>
+```
+
+## Utilisation de la ligne de commande (CLI)
+
+### Installation du CLI
+
+Pour faciliter l'utilisation, utilisez les scripts `sbs` (Linux/macOS) ou `sbs.bat` (Windows) fournis dans le dossier `build/scripts/`. Rendez-les exécutables et ajoutez-les à votre PATH :
+
+```bash
+# Linux/macOS
+chmod +x /chemin/vers/spring-boot-scaffolder/build/scripts/sbs
+ln -s /chemin/vers/spring-boot-scaffolder/build/scripts/sbs /usr/local/bin/sbs
+
+# Windows - Ajoutez le chemin aux variables d'environnement ou créez un raccourci
+```
+
+### Syntaxe de base
+
+```
+sbs generate|g <type> <nom1>[,nom2,...] [options]
+```
+
+Où :
+- `generate` ou `g` est la commande principale
+- `<type>` est le type de composant à générer (voir ci-dessous)
+- `<nom1>[,nom2,...]` sont les noms d'entités, séparés par des virgules
+- `[options]` sont des options supplémentaires comme `--withTests`
+
+### Types de composants disponibles
+
+| Type long     | Alias | Description                             |
+|--------------:|:-----:|:----------------------------------------|
+| `entity`      | `e`   | Génère uniquement des entités JPA       |
+| `dto`         | `d`   | Génère uniquement des DTOs              |
+| `repository`  | `r`   | Génère uniquement des repositories      |
+| `service`     | `s`   | Génère les interfaces et impls service  |
+| `controller`  | `c`   | Génère uniquement des controllers REST  |
+| `mapper`      | `m`   | Génère uniquement des mappers MapStruct |
+| `crud`        |       | Génère tous les composants ci-dessus    |
+
+### Options
+
+| Option        | Description                             |
+|--------------:|:----------------------------------------|
+| `--withTests` | Génère également des tests unitaires    |
+
+## Génération sélective de composants
+
+### Générer uniquement des entités
+
+```bash
+sbs g entity User,Product
+# ou avec l'alias
+sbs g e User,Product
+```
+
+**Résultat :** Génère uniquement `UserEntity.java` et `ProductEntity.java`.
+
+### Générer uniquement des DTOs
+
+```bash
+sbs g dto Customer
+# ou avec l'alias
+sbs g d Customer
+```
+
+**Résultat :** Génère uniquement `CustomerDto.java`.
+
+### Générer uniquement des repositories
+
+```bash
+sbs g repository Order,Invoice
+# ou avec l'alias
+sbs g r Order,Invoice
+```
+
+**Résultat :** Génère uniquement `OrderRepository.java` et `InvoiceRepository.java`.
+
+### Générer uniquement des services
+
+```bash
+sbs g service Payment
+# ou avec l'alias
+sbs g s Payment
+```
+
+**Résultat :** Génère `PaymentService.java` et `PaymentServiceImpl.java`.
+
+### Générer uniquement des controllers
+
+```bash
+sbs g controller Category,Tag
+# ou avec l'alias
+sbs g c Category,Tag
+```
+
+**Résultat :** Génère uniquement `CategoryController.java` et `TagController.java`.
+
+### Générer uniquement des mappers
+
+```bash
+sbs g mapper Address
+# ou avec l'alias
+sbs g m Address
+```
+
+**Résultat :** Génère uniquement `AddressMapper.java`.
+
+### Générer tous les composants (CRUD complet)
+
+```bash
+sbs g crud User,Product --withTests
+```
+
+**Résultat :** Génère tous les composants pour les entités User et Product, ainsi que leurs tests unitaires.
+
+## Mode interactif
+
+Le mode interactif vous permet d'exécuter plusieurs commandes sans avoir à relancer le script :
+
+```bash
+sbs interactive
+```
+
+Un prompt `spring>` apparaîtra, où vous pourrez saisir vos commandes :
+
+```
+spring> g e User
+spring> g c Product
+spring> g crud Customer --withTests
+spring> help
+spring> exit
+```
+
+## Personnalisation des templates
+
+Les templates utilisés pour la génération se trouvent dans le dossier `src/main/resources/templates/`. Vous pouvez les personnaliser selon vos besoins :
+
+1. Copiez le dossier `templates` dans votre propre projet
+2. Modifiez les fichiers `.ftl` selon vos besoins
+3. Configurez le chemin vers vos templates personnalisés
+
+## Bonnes pratiques
+
+- Générez vos entités au début du développement
+- Personnalisez les ensuite pour ajouter des validations, relations, etc.
+- Utilisez les tests générés comme point de départ pour écrire vos tests réels
+- Intégrez la génération dans votre workflow de développement
+
+## Résolution de problèmes
+
+### Problèmes courants
+
+1. **Les classes ne sont pas générées au bon endroit**
+   - Assurez-vous d'exécuter la commande à la racine de votre projet
+   - Vérifiez la structure de vos packages
+
+2. **Erreurs de compilation dans les mappers générés**
+   - Vérifiez que MapStruct est correctement configuré
+   - Assurez-vous que les annotations processors sont correctement configurés
+
+3. **La classe PagedResponse n'est pas trouvée**
+   - Cette classe est générée automatiquement dans le package dto de votre application
+   - Si vous avez des erreurs, générez-la manuellement : `sbs g dto PagedResponse`
+
+## Test de la bibliothèque en local
+
+Pour tester et utiliser la bibliothèque Spring Boot Scaffolder en local, suivez ces étapes :
+
+### 1. Construire le projet
+
+Commencez par compiler et construire le projet :
+
+```bash
+# À la racine du projet spring-boot-scaffolder
+./gradlew build
+```
+
+Cette commande compile le code, exécute les tests et génère les fichiers JAR dans le dossier `build/libs/`.
+
+### 2. Installation locale
+
+#### Option 1 : Installer dans votre dépôt local Maven
+
+```bash
+# À la racine du projet spring-boot-scaffolder
+./gradlew publishToMavenLocal
+```
+
+Cela publiera la bibliothèque dans votre dépôt Maven local (`~/.m2/repository/`), vous permettant de l'utiliser dans vos projets locaux.
+
+##### Résolution des problèmes de signature GPG
+
+Si vous rencontrez une erreur comme celle-ci :
+```
+> Task :signMavenJavaPublication FAILED
+A problem occurred starting process 'command 'gpg''
+```
+
+Vous avez deux options :
+
+1. **Désactiver la signature GPG** (recommandé pour les tests locaux) :
+   ```bash
+   # Option 1: Avec une variable d'environnement
+   export ORG_GRADLE_PROJECT_signingRequired=false
+   ./gradlew publishToMavenLocal
+   
+   # Option 2: Avec une propriété Gradle
+   ./gradlew publishToMavenLocal -PsigningRequired=false
+   ```
+
+2. **Configurer GPG correctement** (nécessaire seulement pour la publication externe) :
+   - Installez GPG : `brew install gnupg` (macOS) ou `apt-get install gnupg` (Linux)
+   - Générez une clé : `gpg --gen-key`
+   - Utilisez cette clé dans votre fichier `~/.gradle/gradle.properties` :
+     ```
+     signing.keyId=VOTREKEYID
+     signing.password=VOTREMOTDEPASSE
+     signing.secretKeyRingFile=/chemin/vers/fichier/secring.gpg
+     ```
+
+#### Option 2 : Utiliser directement les fichiers JAR
+
+Les fichiers JAR générés se trouvent dans le dossier `build/libs/` :
+- `spring-boot-scaffolder-2.1.1.jar` - Le JAR principal
+- `spring-boot-scaffolder-2.1.1-sources.jar` - Les sources
+- `spring-boot-scaffolder-2.1.1-javadoc.jar` - La Javadoc
+
+### 3. Utiliser les scripts CLI directement
+
+Les scripts CLI sont générés dans le dossier `build/scripts/` :
+
+```bash
+# Rendre le script exécutable (Linux/macOS)
+chmod +x build/scripts/sbs
+
+# Exécuter en mode interactif
+./build/scripts/sbs interactive
+
+# Ou générer un composant
+./build/scripts/sbs g crud User
+```
+
+### 4. Tester dans un projet Spring Boot
+
+#### Projet Gradle
+
+Dans le `build.gradle` de votre projet Spring Boot :
+
+```groovy
+buildscript {
+    repositories {
+        mavenLocal() // Ajouter pour utiliser le dépôt local
+        mavenCentral()
+    }
+    dependencies {
+        classpath "io.github.grafx1.scaffolder:spring-boot-scaffolder:2.1.1"
+    }
+}
+
+plugins {
+    id 'org.springframework.boot' version '3.2.0'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+apply plugin: 'io.github.grafx1.scaffolder'
+```
+
+Puis exécutez :
+
+```bash
+./gradlew scaffold -PentityName="User" -PwithTests=true
+```
+
+#### Projet Maven
+
+Dans le `pom.xml` de votre projet Spring Boot :
+
+```xml
+<dependency>
+    <groupId>io.github.grafx1.scaffolder</groupId>
+    <artifactId>spring-boot-scaffolder</artifactId>
+    <version>2.1.1</version>
+</dependency>
+```
+
+Puis exécutez :
+
+```bash
+mvn exec:java -DmainClass=io.github.grafx1.scaffolder.cli.SpringBootScaffolderCLI -Dexec.args="g crud User --withTests"
+```
+
+### 5. Déboguer la bibliothèque
+
+Pour déboguer la bibliothèque pendant son utilisation :
+
+1. Créez une configuration de débogage dans votre IDE pointant vers `io.github.grafx1.scaffolder.cli.SpringBootScaffolderCLI`
+2. Ajoutez les arguments nécessaires (ex: `g crud User`)
+3. Lancez en mode débogage
+
+## Contribuer au projet
+
+Nous accueillons vos contributions ! Voici comment vous pouvez participer :
+
+1. Consultez notre fichier [CONTRIBUTION_SUGGESTIONS.md](CONTRIBUTION_SUGGESTIONS.md)
+2. Créez une issue pour discuter de votre proposition
+3. Soumettez une pull request avec vos modifications
+
+---
+
+© 2023-2025 Spring Boot Scaffolder | Licence MIT

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,19 @@ repositories {
 dependencies {
     implementation 'org.freemarker:freemarker:2.3.32'
 
+    // Dépendances pour les tests
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
+
+    // Ajout des dépendances nécessaires pour tester les composants générés
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.2.0'
+    testImplementation 'org.springframework.boot:spring-boot-starter-web:3.2.0'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.2.0'
+    testImplementation 'org.mapstruct:mapstruct:1.6.3'
+    testImplementation 'org.hamcrest:hamcrest-core:2.2'
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
+    testImplementation 'com.h2database:h2:2.2.224'  // Base de données en mémoire pour les tests
 }
 
 tasks.named('test') {
@@ -95,18 +105,29 @@ publishing {
     }
 }
 
-signing {
-    useGpgCmd()
-    sign publishing.publications.mavenJava
-}
+// Rendre la signature conditionnelle
+boolean isSigningEnabled = !project.hasProperty('skipSigning')
 
-nexusPublishing {
-    repositories {
-        sonatype {
-            username = findProperty("ossrhUsername")
-            password = findProperty("ossrhPassword")
-        }
+// Désactive complètement la signature si skipSigning est présent
+if (isSigningEnabled) {
+    signing {
+        useGpgCmd()
+        sign publishing.publications
     }
+} else {
+    // Crée une configuration de signature vide pour éviter les erreurs
+    // mais n'associe aucune tâche de signature réelle
+    signing {
+        required = false
+        sign publishing.publications
+    }
+
+    // Désactive explicitement les tâches de signature
+    tasks.withType(Sign).configureEach {
+        enabled = false
+    }
+
+    println "Signature GPG désactivée avec -PskipSigning"
 }
 
 // Corrige les dépendances entre les tâches de signature et de publication
@@ -167,7 +188,4 @@ tasks.register('createCentralBundle', Zip) {
     archiveFileName = 'central-bundle.zip'
     destinationDirectory = layout.buildDirectory
 }
-
-
-
 

--- a/src/main/java/io/github/grafx1/scaffolder/EnhancedGeneratorService.java
+++ b/src/main/java/io/github/grafx1/scaffolder/EnhancedGeneratorService.java
@@ -1,0 +1,289 @@
+package io.github.grafx1.scaffolder;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateExceptionHandler;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.github.grafx1.scaffolder.utils.Tools.*;
+
+/**
+ * Service responsable de la génération de code pour les différents composants
+ * d'une application Spring Boot. Cette version améliorée permet la génération
+ * sélective de composants individuels et prend en compte un dossier de sortie personnalisé.
+ */
+public class EnhancedGeneratorService {
+
+    // Types de composants supportés
+    public static final String ENTITY = "Entity";
+    public static final String DTO = "Dto";
+    public static final String REPOSITORY = "Repository";
+    public static final String SERVICE = "Service";
+    public static final String SERVICE_IMPL = "ServiceImpl";
+    public static final String CONTROLLER = "Controller";
+    public static final String MAPPER = "Mapper";
+
+    // Structure des sous-packages pour chaque type de composant
+    private static final Map<String, String> SUBPACKAGES = Map.of(
+            ENTITY, "entity",
+            DTO, "dto",
+            REPOSITORY, "repository",
+            SERVICE, "service",
+            SERVICE_IMPL, "service.impl",
+            CONTROLLER, "controller",
+            MAPPER, "mapper"
+    );
+
+    // Configuration pour les templates
+    private final Configuration cfgMain;
+    private final Configuration cfgTest;
+
+    /**
+     * Initialise le service de génération avec les configurations FreeMarker
+     */
+    public EnhancedGeneratorService() {
+        cfgMain = new Configuration(Configuration.VERSION_2_3_32);
+        cfgMain.setDefaultEncoding("UTF-8");
+        cfgMain.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+        cfgMain.setLogTemplateExceptions(false);
+        cfgMain.setWrapUncheckedExceptions(true);
+        cfgMain.setClassLoaderForTemplateLoading(getClass().getClassLoader(), "templates");
+
+        cfgTest = new Configuration(Configuration.VERSION_2_3_32);
+        cfgTest.setDefaultEncoding("UTF-8");
+        cfgTest.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+        cfgTest.setLogTemplateExceptions(false);
+        cfgTest.setWrapUncheckedExceptions(true);
+        cfgTest.setClassLoaderForTemplateLoading(getClass().getClassLoader(), "templates/test");
+    }
+
+    /**
+     * Génère la structure complète (tous les composants) pour les entités spécifiées
+     *
+     * @param entityNames Les noms des entités séparés par des virgules
+     * @param baseDir Le répertoire de base du projet
+     * @param withTests Indique si les tests unitaires doivent être générés
+     */
+    public void generateStructure(String entityNames, Path baseDir, boolean withTests) {
+        Arrays.stream(entityNames.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .forEach(entity -> {
+                    if (entity.split("\\.").length > 1) {
+                        printHelp();
+                        throw new IllegalArgumentException("Invalid entity name : " + entity);
+                    }
+                    String fqcn = computeFQCNFromProject(baseDir, entity);
+                    System.out.println("fqcn : " + fqcn);
+
+                    // Utilisation du dossier de base adapté pour les tests
+                    Path effectiveBaseDir = getEffectiveBaseDir(baseDir);
+                    printFooter(fqcn, withTests, effectiveBaseDir.toString());
+
+                    generateAllComponents(fqcn, effectiveBaseDir, withTests);
+                });
+
+        System.out.println(GREEN + "\n Scaffold generated successfully!" + RESET);
+    }
+
+    /**
+     * Génère tous les composants pour une entité spécifique
+     */
+    public void generateAllComponents(String fqcn, Path baseDir, boolean withTests) {
+        // Obtenir le dossier de base effectif (pour les tests)
+        Path effectiveBaseDir = getEffectiveBaseDir(baseDir);
+
+        // Générer la classe PagedResponse si nécessaire
+        generatePagedResponse(getBaseAppPackage(fqcn), effectiveBaseDir);
+
+        // Générer tous les composants
+        generateEntityComponent(fqcn, effectiveBaseDir, withTests);
+        generateDtoComponent(fqcn, effectiveBaseDir, withTests);
+        generateRepositoryComponent(fqcn, effectiveBaseDir, withTests);
+        generateServiceComponent(fqcn, effectiveBaseDir, withTests);
+        generateServiceImplComponent(fqcn, effectiveBaseDir, withTests);
+        generateControllerComponent(fqcn, effectiveBaseDir, withTests);
+        generateMapperComponent(fqcn, effectiveBaseDir, withTests);
+    }
+
+    /**
+     * Détermine le dossier de base effectif en prenant en compte la propriété système scaffolder.output.dir
+     * Cette méthode est utilisée pour rediriger la génération vers un dossier spécifique pendant les tests
+     */
+    private Path getEffectiveBaseDir(Path baseDir) {
+        String outputDir = System.getProperty("scaffolder.output.dir");
+        if (outputDir != null && !outputDir.isEmpty()) {
+            System.out.println("Using output directory from system property: " + outputDir);
+            return Paths.get(outputDir);
+        }
+        return baseDir;
+    }
+
+    /**
+     * Génère uniquement le composant Entity
+     */
+    public void generateEntityComponent(String fqcn, Path baseDir, boolean withTests) {
+        generateComponent(fqcn, getEffectiveBaseDir(baseDir), ENTITY, withTests);
+    }
+
+    /**
+     * Génère uniquement le composant DTO
+     */
+    public void generateDtoComponent(String fqcn, Path baseDir, boolean withTests) {
+        generateComponent(fqcn, getEffectiveBaseDir(baseDir), DTO, withTests);
+    }
+
+    /**
+     * Génère uniquement le composant Repository
+     */
+    public void generateRepositoryComponent(String fqcn, Path baseDir, boolean withTests) {
+        generateComponent(fqcn, getEffectiveBaseDir(baseDir), REPOSITORY, withTests);
+    }
+
+    /**
+     * Génère uniquement le composant Service (interface)
+     */
+    public void generateServiceComponent(String fqcn, Path baseDir, boolean withTests) {
+        generateComponent(fqcn, getEffectiveBaseDir(baseDir), SERVICE, withTests);
+    }
+
+    /**
+     * Génère uniquement le composant ServiceImpl
+     */
+    public void generateServiceImplComponent(String fqcn, Path baseDir, boolean withTests) {
+        generateComponent(fqcn, getEffectiveBaseDir(baseDir), SERVICE_IMPL, withTests);
+    }
+
+    /**
+     * Génère uniquement le composant Controller
+     */
+    public void generateControllerComponent(String fqcn, Path baseDir, boolean withTests) {
+        generateComponent(fqcn, getEffectiveBaseDir(baseDir), CONTROLLER, withTests);
+    }
+
+    /**
+     * Génère uniquement le composant Mapper
+     */
+    public void generateMapperComponent(String fqcn, Path baseDir, boolean withTests) {
+        generateComponent(fqcn, getEffectiveBaseDir(baseDir), MAPPER, withTests);
+    }
+
+    /**
+     * Méthode générique pour générer un composant spécifique
+     */
+    private void generateComponent(String fqcn, Path baseDir, String componentType, boolean withTests) {
+        String[] parts = fqcn.split("\\.");
+        String className = parts[parts.length - 1];
+        String basePackage = getBasePackage(fqcn);
+        String baseAppPackage = getBaseAppPackage(fqcn);
+        String subPackage = SUBPACKAGES.get(componentType);
+
+        if (subPackage == null) {
+            throw new IllegalArgumentException("Type de composant non supporté : " + componentType);
+        }
+
+        // Préparation des données pour le template
+        Map<String, Object> data = new HashMap<>();
+        data.put("className", className);
+        data.put("classNameLower", className.toLowerCase());
+        data.put("basePackage", baseAppPackage);
+        data.put("packageName", basePackage);
+
+        // Génération du fichier de composant
+        String fullPackage = basePackage + "." + subPackage;
+        String outputDir = baseDir + "/src/main/java/" + fullPackage.replace('.', '/');
+        String outputFile = className + componentType + ".java";
+        String templateName = componentType + "Template.java.ftl";
+
+        // Si c'est ServiceImpl, on ajuste le nom du template
+        if (SERVICE_IMPL.equals(componentType)) {
+            templateName = "ServiceImplTemplate.java.ftl";
+        }
+
+        generateFile(cfgMain, templateName, outputDir, outputFile, data);
+        System.out.println(GREEN + "Généré: " + outputFile + RESET);
+
+        // Génération des tests si demandé
+        if (withTests && shouldGenerateTest(componentType)) {
+            String testOutputDir = baseDir + "/src/test/java/" + fullPackage.replace('.', '/');
+            String testOutputFile = className + componentType + "Test.java";
+            String testTemplate = componentType + "TemplateTest.java.ftl";
+
+            // ServiceImpl n'a pas de test, on utilise le test du Service
+            if (SERVICE_IMPL.equals(componentType)) {
+                return;
+            }
+
+            generateFile(cfgTest, testTemplate, testOutputDir, testOutputFile, data);
+            System.out.println(GREEN + "Généré: " + testOutputFile + RESET);
+        }
+    }
+
+    /**
+     * Détermine si on doit générer un test pour le type de composant donné
+     */
+    private boolean shouldGenerateTest(String componentType) {
+        return CONTROLLER.equals(componentType) ||
+               SERVICE.equals(componentType) ||
+               MAPPER.equals(componentType);
+    }
+
+    /**
+     * Génère la classe PagedResponse.java si elle n'existe pas déjà
+     */
+    private void generatePagedResponse(String packageName, Path baseDir) {
+        String outputDir = baseDir + "/src/main/java/" + packageName.replace('.', '/') + "/dto/";
+        Path dir = Paths.get(outputDir);
+        File file = dir.resolve("PagedResponse.java").toFile();
+
+        if (!file.exists()) {
+            Map<String, Object> data = Map.of("packageName", packageName);
+            generateFile(cfgMain, "PagedResponseTemplate.java.ftl", outputDir, "PagedResponse.java", data);
+            System.out.println(GREEN + "Généré: PagedResponse.java" + RESET);
+        } else {
+            System.out.println(YELLOW + "PagedResponse.java existe déjà, génération ignorée." + RESET);
+        }
+    }
+
+    /**
+     * Génère un fichier à partir d'un template FreeMarker
+     */
+    private void generateFile(Configuration cfg, String templateName, String outputDir, String outputFile, Map<String, Object> data) {
+        try {
+            Template template = cfg.getTemplate(templateName);
+            Path dirPath = Paths.get(outputDir);
+            Files.createDirectories(dirPath);
+            try (Writer writer = new FileWriter(dirPath.resolve(outputFile).toFile())) {
+                template.process(data, writer);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Échec de la génération du fichier: " + outputFile, e);
+        }
+    }
+
+    /**
+     * Extrait le package de base à partir du FQCN
+     */
+    private String getBasePackage(String fqcn) {
+        String[] parts = fqcn.split("\\.");
+        return String.join(".", Arrays.copyOf(parts, parts.length - 1));
+    }
+
+    /**
+     * Extrait le package de l'application à partir du FQCN
+     */
+    private String getBaseAppPackage(String fqcn) {
+        String[] parts = fqcn.split("\\.");
+        return String.join(".", Arrays.copyOf(parts, parts.length - 2));
+    }
+}

--- a/src/main/java/io/github/grafx1/scaffolder/cli/SpringBootScaffolderCLI.java
+++ b/src/main/java/io/github/grafx1/scaffolder/cli/SpringBootScaffolderCLI.java
@@ -1,0 +1,281 @@
+package io.github.grafx1.scaffolder.cli;
+
+import io.github.grafx1.scaffolder.EnhancedGeneratorService;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Scanner;
+
+import static io.github.grafx1.scaffolder.utils.Tools.*;
+
+/**
+ * CLI amélioré pour Spring Boot Scaffolder permettant une utilisation plus interactive
+ * et des commandes à la façon d'Angular CLI ou Spring CLI.
+ */
+public class SpringBootScaffolderCLI {
+
+    private static final String GENERATE_COMMAND = "generate";
+    private static final String GENERATE_ALIAS = "g";
+
+    private static final String ENTITY_TYPE = "entity";
+    private static final String ENTITY_ALIAS = "e";
+    private static final String DTO_TYPE = "dto";
+    private static final String DTO_ALIAS = "d";
+    private static final String REPOSITORY_TYPE = "repository";
+    private static final String REPOSITORY_ALIAS = "r";
+    private static final String SERVICE_TYPE = "service";
+    private static final String SERVICE_ALIAS = "s";
+    private static final String CONTROLLER_TYPE = "controller";
+    private static final String CONTROLLER_ALIAS = "c";
+    private static final String MAPPER_TYPE = "mapper";
+    private static final String MAPPER_ALIAS = "m";
+    private static final String CRUD_TYPE = "crud";
+    private static final String ALL_TYPE = "all";
+
+    private final EnhancedGeneratorService generatorService;
+    private final Path baseDir;
+
+    public SpringBootScaffolderCLI() {
+        this.generatorService = new EnhancedGeneratorService();
+        this.baseDir = Path.of("").toAbsolutePath();
+    }
+
+    /**
+     * Point d'entrée principal du CLI
+     */
+    public static void main(String[] args) {
+        printHeader();
+
+        SpringBootScaffolderCLI cli = new SpringBootScaffolderCLI();
+
+        if (args.length == 0) {
+            cli.runInteractiveMode();
+        } else {
+            cli.parseCommands(args);
+        }
+    }
+
+    /**
+     * Démarre le mode interactif du CLI
+     */
+    private void runInteractiveMode() {
+        System.out.println(CYAN + "Mode interactif de Spring Boot Scaffolder" + RESET);
+        System.out.println(YELLOW + "Tapez 'exit' ou 'quit' pour quitter, 'help' pour l'aide" + RESET);
+
+        Scanner scanner = new Scanner(System.in);
+        boolean running = true;
+
+        while (running) {
+            System.out.print(GREEN + "spring> " + RESET);
+            String input = scanner.nextLine().trim();
+
+            if (input.equalsIgnoreCase("exit") || input.equalsIgnoreCase("quit")) {
+                running = false;
+                System.out.println(YELLOW + "Au revoir!" + RESET);
+            } else if (input.equalsIgnoreCase("help")) {
+                printCliHelp();
+            } else if (!input.isEmpty()) {
+                parseCommands(input.split("\\s+"));
+            }
+        }
+
+        scanner.close();
+    }
+
+    /**
+     * Analyse et exécute les commandes passées en arguments
+     */
+    private void parseCommands(String[] args) {
+        if (args.length == 0) {
+            printCliHelp();
+            return;
+        }
+
+        String command = args[0].toLowerCase();
+
+        // Gestion de la commande d'aide
+        if (command.equals("help") || command.equals("--help") || command.equals("-h")) {
+            printCliHelp();
+            return;
+        }
+
+        // Gestion de la commande de génération
+        if (command.equals(GENERATE_COMMAND) || command.equals(GENERATE_ALIAS)) {
+            if (args.length < 3) {
+                System.out.println(RED + "Erreur: Les commandes generate nécessitent un type et un nom" + RESET);
+                printCliHelp();
+                return;
+            }
+
+            String type = args[1].toLowerCase();
+            String names = args[2];
+            boolean withTests = args.length > 3 && args[3].equalsIgnoreCase("--withTests");
+
+            generateByType(type, names, withTests);
+        } else {
+            System.out.println(RED + "Commande non reconnue: " + command + RESET);
+            printCliHelp();
+        }
+    }
+
+    /**
+     * Génère les fichiers en fonction du type demandé
+     */
+    private void generateByType(String type, String names, boolean withTests) {
+        switch (type) {
+            case ENTITY_TYPE:
+            case ENTITY_ALIAS:
+                generateEntityOnly(names);
+                break;
+            case DTO_TYPE:
+            case DTO_ALIAS:
+                generateDtoOnly(names);
+                break;
+            case REPOSITORY_TYPE:
+            case REPOSITORY_ALIAS:
+                generateRepositoryOnly(names);
+                break;
+            case SERVICE_TYPE:
+            case SERVICE_ALIAS:
+                generateServiceOnly(names);
+                break;
+            case CONTROLLER_TYPE:
+            case CONTROLLER_ALIAS:
+                generateControllerOnly(names);
+                break;
+            case MAPPER_TYPE:
+            case MAPPER_ALIAS:
+                generateMapperOnly(names);
+                break;
+            case CRUD_TYPE:
+            case ALL_TYPE:
+                generateAllLayers(names, withTests);
+                break;
+            default:
+                System.out.println(RED + "Type non reconnu: " + type + RESET);
+                printCliHelp();
+        }
+    }
+
+    /**
+     * Génère uniquement les entités
+     */
+    private void generateEntityOnly(String names) {
+        System.out.println(CYAN + "Génération des entités: " + names + RESET);
+        processNamesForComponent(names, false, (fqcn, withTests) ->
+            generatorService.generateEntityComponent(fqcn, baseDir, withTests));
+    }
+
+    /**
+     * Génère uniquement les DTOs
+     */
+    private void generateDtoOnly(String names) {
+        System.out.println(CYAN + "Génération des DTOs: " + names + RESET);
+        processNamesForComponent(names, false, (fqcn, withTests) ->
+            generatorService.generateDtoComponent(fqcn, baseDir, withTests));
+    }
+
+    /**
+     * Génère uniquement les repositories
+     */
+    private void generateRepositoryOnly(String names) {
+        System.out.println(CYAN + "Génération des repositories: " + names + RESET);
+        processNamesForComponent(names, false, (fqcn, withTests) ->
+            generatorService.generateRepositoryComponent(fqcn, baseDir, withTests));
+    }
+
+    /**
+     * Génère uniquement les services
+     */
+    private void generateServiceOnly(String names) {
+        System.out.println(CYAN + "Génération des services: " + names + RESET);
+        processNamesForComponent(names, false, (fqcn, withTests) -> {
+            generatorService.generateServiceComponent(fqcn, baseDir, withTests);
+            generatorService.generateServiceImplComponent(fqcn, baseDir, withTests);
+        });
+    }
+
+    /**
+     * Génère uniquement les controllers
+     */
+    private void generateControllerOnly(String names) {
+        System.out.println(CYAN + "Génération des controllers: " + names + RESET);
+        processNamesForComponent(names, false, (fqcn, withTests) ->
+            generatorService.generateControllerComponent(fqcn, baseDir, withTests));
+    }
+
+    /**
+     * Génère uniquement les mappers
+     */
+    private void generateMapperOnly(String names) {
+        System.out.println(CYAN + "Génération des mappers: " + names + RESET);
+        processNamesForComponent(names, false, (fqcn, withTests) ->
+            generatorService.generateMapperComponent(fqcn, baseDir, withTests));
+    }
+
+    /**
+     * Génère tous les composants pour les entités spécifiées (CRUD complet)
+     */
+    private void generateAllLayers(String names, boolean withTests) {
+        System.out.println(CYAN + "Génération de la structure CRUD complète pour: " + names + RESET);
+        System.out.println(withTests ?
+                GREEN + "Les tests unitaires seront également générés" + RESET :
+                YELLOW + "Les tests unitaires ne seront pas générés" + RESET);
+
+        // Utilise le générateur existant pour créer tous les fichiers
+        generatorService.generateStructure(names, baseDir, withTests);
+    }
+
+    /**
+     * Interface fonctionnelle pour traiter chaque entité
+     */
+    @FunctionalInterface
+    private interface EntityProcessor {
+        void process(String fqcn, boolean withTests);
+    }
+
+    /**
+     * Traite chaque nom d'entité et applique le processeur
+     */
+    private void processNamesForComponent(String names, boolean withTests, EntityProcessor processor) {
+        Arrays.stream(names.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .forEach(entity -> {
+                if (entity.split("\\.").length > 1) {
+                    printHelp();
+                    throw new IllegalArgumentException("Invalid entity name : " + entity);
+                }
+                String fqcn = computeFQCNFromProject(baseDir, entity);
+                System.out.println("fqcn : " + fqcn);
+
+                // Appliquer le processeur pour cette entité
+                processor.process(fqcn, withTests);
+            });
+
+        System.out.println(GREEN + "\nGénération terminée avec succès!" + RESET);
+    }
+
+    /**
+     * Affiche l'aide du CLI
+     */
+    private void printCliHelp() {
+        System.out.println("\n" + CYAN + "Spring Boot Scaffolder CLI - Guide d'utilisation" + RESET);
+        System.out.println("\nCommandes disponibles:");
+        System.out.println(GREEN + "  spring generate|g crud <nom1>[,nom2,...] [--withTests]" + RESET + " - Génère une structure CRUD complète");
+        System.out.println(GREEN + "  spring generate|g entity|e <nom1>[,nom2,...]" + RESET + " - Génère uniquement des entités");
+        System.out.println(GREEN + "  spring generate|g dto|d <nom1>[,nom2,...]" + RESET + " - Génère uniquement des DTOs");
+        System.out.println(GREEN + "  spring generate|g repository|r <nom1>[,nom2,...]" + RESET + " - Génère uniquement des repositories");
+        System.out.println(GREEN + "  spring generate|g service|s <nom1>[,nom2,...]" + RESET + " - Génère uniquement des services");
+        System.out.println(GREEN + "  spring generate|g controller|c <nom1>[,nom2,...]" + RESET + " - Génère uniquement des controllers");
+        System.out.println(GREEN + "  spring generate|g mapper|m <nom1>[,nom2,...]" + RESET + " - Génère uniquement des mappers");
+        System.out.println(GREEN + "  help" + RESET + " - Affiche ce guide d'utilisation");
+        System.out.println(GREEN + "  exit|quit" + RESET + " - Quitte le programme en mode interactif");
+
+        System.out.println("\nExemples:");
+        System.out.println(YELLOW + "  spring g crud User,Product --withTests" + RESET);
+        System.out.println(YELLOW + "  spring generate entity Customer" + RESET);
+        System.out.println(YELLOW + "  spring g c Order,Invoice" + RESET);
+        System.out.println();
+    }
+}

--- a/src/main/java/io/github/grafx1/scaffolder/utils/Tools.java
+++ b/src/main/java/io/github/grafx1/scaffolder/utils/Tools.java
@@ -36,6 +36,11 @@ public class Tools {
     public static final String RED = "\u001B[31m";
 
     /**
+     * Yellow hexadecimal code color
+     */
+    public static final String YELLOW = "\u001B[33m";
+
+    /**
      * Extract groupId and artefactId from pom file
      * @param xml
      * @return

--- a/src/test/java/io/github/grafx1/scaffolder/cli/SpringBootScaffolderCLITest.java
+++ b/src/test/java/io/github/grafx1/scaffolder/cli/SpringBootScaffolderCLITest.java
@@ -1,0 +1,383 @@
+package io.github.grafx1.scaffolder.cli;
+
+import io.github.grafx1.scaffolder.utils.Tools;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests pour le CLI amélioré de Spring Boot Scaffolder
+ * Les tests sont exécutés dans un dossier temporaire complètement isolé
+ * pour éviter d'interférer avec la structure du projet principal
+ */
+public class SpringBootScaffolderCLITest {
+
+    @TempDir
+    Path tempDir;
+
+    private ByteArrayOutputStream outputCaptor;
+    private PrintStream originalOut;
+    private String originalUserDir;
+    private String originalOutputDir;
+
+    /**
+     * Configuration à faire avant chaque test
+     */
+    @BeforeEach
+    public void setup() throws IOException {
+        System.err.println("======== TEST SETUP STARTING ========");
+
+        // Sauvegarde du dossier utilisateur actuel
+        originalUserDir = System.getProperty("user.dir");
+        System.err.println("Original user.dir: " + originalUserDir);
+
+        // Sauvegarde du dossier de sortie s'il est défini
+        originalOutputDir = System.getProperty("scaffolder.output.dir");
+        System.err.println("Original scaffolder.output.dir: " + originalOutputDir);
+
+        // Capture la sortie standard pour les assertions
+        outputCaptor = new ByteArrayOutputStream();
+        originalOut = System.out;
+        System.setOut(new PrintStream(outputCaptor));
+
+        // Crée une structure minimale d'application Spring Boot pour les tests
+        createMinimalSpringBootAppStructure(tempDir);
+        System.err.println("Created minimal Spring Boot structure in: " + tempDir);
+
+        // Configure le test pour utiliser le dossier temporaire comme dossier courant
+        System.setProperty("user.dir", tempDir.toString());
+        System.err.println("Set user.dir to: " + tempDir);
+
+        // Configure le dossier de sortie pour que les fichiers générés aillent dans un sous-dossier du dossier temporaire
+        Path outputDir = tempDir.resolve("output");
+        Files.createDirectories(outputDir);
+        System.setProperty("scaffolder.output.dir", outputDir.toString());
+        System.err.println("Set scaffolder.output.dir to: " + outputDir);
+
+        System.err.println("======== TEST SETUP COMPLETE ========");
+    }
+
+    /**
+     * Nettoyage à faire après chaque test
+     */
+    @AfterEach
+    public void tearDown() {
+        System.err.println("======== TEST TEARDOWN STARTING ========");
+
+        // Restaure la sortie standard
+        System.setOut(originalOut);
+        System.err.println("Restored original System.out");
+
+        // Restaure le dossier utilisateur d'origine
+        System.setProperty("user.dir", originalUserDir);
+        System.err.println("Restored user.dir to: " + originalUserDir);
+
+        // Restaure le dossier de sortie d'origine
+        if (originalOutputDir != null) {
+            System.setProperty("scaffolder.output.dir", originalOutputDir);
+            System.err.println("Restored scaffolder.output.dir to: " + originalOutputDir);
+        } else {
+            System.clearProperty("scaffolder.output.dir");
+            System.err.println("Cleared scaffolder.output.dir property");
+        }
+
+        System.err.println("Test directory: " + tempDir);
+
+        try {
+            // Liste les fichiers générés pour faciliter le débogage (limité aux fichiers Java)
+            System.err.println("Generated files:");
+            Files.walk(tempDir)
+                .filter(Files::isRegularFile)
+                .filter(p -> p.toString().endsWith(".java"))
+                .forEach(p -> System.err.println("  - " + p));
+        } catch (IOException e) {
+            System.err.println("Error listing files: " + e.getMessage());
+        }
+
+        System.err.println("======== TEST TEARDOWN COMPLETE ========");
+    }
+
+    @Test
+    public void testEntityGeneration() throws Exception {
+        // Configuration du test
+        String[] args = {"generate", "entity", "User"};
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Attendre un peu pour s'assurer que les fichiers sont créés
+        Thread.sleep(500);
+
+        // Vérifications
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Génération des entités: User");
+
+        // Le chemin exact des fichiers dépend de la façon dont le package est déterminé dans votre application
+        // Utilisons une approche plus générique pour trouver le fichier généré
+        List<Path> entityFiles = findGeneratedFiles(tempDir, "UserEntity.java");
+        assertThat(entityFiles).isNotEmpty();
+        assertThat(entityFiles.get(0).toString()).contains("entity");
+    }
+
+    @Test
+    public void testDtoGeneration() throws Exception {
+        // Configuration du test
+        String[] args = {"g", "dto", "Product"};
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Attendre un peu pour s'assurer que les fichiers sont créés
+        Thread.sleep(500);
+
+        // Vérifications
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Génération des DTOs: Product");
+
+        // Approche générique pour trouver le fichier
+        List<Path> dtoFiles = findGeneratedFiles(tempDir, "ProductDto.java");
+        assertThat(dtoFiles).isNotEmpty();
+        assertThat(dtoFiles.get(0).toString()).contains("dto");
+    }
+
+    @Test
+    public void testRepositoryGeneration() throws Exception {
+        // Configuration du test
+        String[] args = {"g", "r", "Order"};
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Attendre un peu pour s'assurer que les fichiers sont créés
+        Thread.sleep(500);
+
+        // Vérifications
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Génération des repositories: Order");
+
+        // Approche générique pour trouver le fichier
+        List<Path> repoFiles = findGeneratedFiles(tempDir, "OrderRepository.java");
+        assertThat(repoFiles).isNotEmpty();
+        assertThat(repoFiles.get(0).toString()).contains("repository");
+    }
+
+    @Test
+    public void testControllerGeneration() throws Exception {
+        // Configuration du test
+        String[] args = {"g", "c", "Customer"};
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Attendre un peu pour s'assurer que les fichiers sont créés
+        Thread.sleep(500);
+
+        // Vérifications
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Génération des controllers: Customer");
+
+        // Approche générique pour trouver le fichier
+        List<Path> controllerFiles = findGeneratedFiles(tempDir, "CustomerController.java");
+        assertThat(controllerFiles).isNotEmpty();
+        assertThat(controllerFiles.get(0).toString()).contains("controller");
+    }
+
+    @Test
+    public void testMapperGeneration() throws Exception {
+        // Configuration du test
+        String[] args = {"g", "m", "Invoice"};
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Attendre un peu pour s'assurer que les fichiers sont créés
+        Thread.sleep(500);
+
+        // Vérifications
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Génération des mappers: Invoice");
+
+        // Approche générique pour trouver le fichier
+        List<Path> mapperFiles = findGeneratedFiles(tempDir, "InvoiceMapper.java");
+        assertThat(mapperFiles).isNotEmpty();
+        assertThat(mapperFiles.get(0).toString()).contains("mapper");
+    }
+
+    @Test
+    public void testServiceGeneration() throws Exception {
+        // Configuration du test
+        String[] args = {"g", "s", "Payment"};
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Attendre un peu pour s'assurer que les fichiers sont créés
+        Thread.sleep(500);
+
+        // Vérifications
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Génération des services: Payment");
+
+        // Approche générique pour trouver les fichiers
+        List<Path> serviceFiles = findGeneratedFiles(tempDir, "PaymentService.java");
+        List<Path> serviceImplFiles = findGeneratedFiles(tempDir, "PaymentServiceImpl.java");
+
+        assertThat(serviceFiles).isNotEmpty();
+        assertThat(serviceImplFiles).isNotEmpty();
+        assertThat(serviceFiles.get(0).toString()).contains("service");
+        assertThat(serviceImplFiles.get(0).toString()).contains("service" + File.separator + "impl");
+    }
+
+    @Test
+    public void testCrudGeneration() throws Exception {
+        // Configuration du test - générer sans tests pour éviter les problèmes de compilation
+        // car les tests générés dépendent de classes qui n'existent pas dans l'environnement de test
+        String[] args = {"g", "crud", "Booking"}; // Sans l'option --withTests
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Attendre un peu pour s'assurer que les fichiers sont créés
+        Thread.sleep(1000);
+
+        // Vérifications
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Génération de la structure CRUD complète pour: Booking");
+
+        // Recherche par nom de fichier, plus robuste que des chemins hardcodés
+        List<Path> entityFiles = findGeneratedFiles(tempDir, "BookingEntity.java");
+        List<Path> dtoFiles = findGeneratedFiles(tempDir, "BookingDto.java");
+        List<Path> repoFiles = findGeneratedFiles(tempDir, "BookingRepository.java");
+        List<Path> serviceFiles = findGeneratedFiles(tempDir, "BookingService.java");
+        List<Path> implFiles = findGeneratedFiles(tempDir, "BookingServiceImpl.java");
+        List<Path> controllerFiles = findGeneratedFiles(tempDir, "BookingController.java");
+        List<Path> mapperFiles = findGeneratedFiles(tempDir, "BookingMapper.java");
+
+        // Vérifier que les fichiers principaux sont générés
+        assertThat(entityFiles).isNotEmpty();
+        assertThat(dtoFiles).isNotEmpty();
+        assertThat(repoFiles).isNotEmpty();
+        assertThat(serviceFiles).isNotEmpty();
+        assertThat(implFiles).isNotEmpty();
+        assertThat(controllerFiles).isNotEmpty();
+        assertThat(mapperFiles).isNotEmpty();
+    }
+
+    /**
+     * Test spécifique pour la fonctionnalité de génération avec tests unitaires
+     * Ce test vérifie seulement que l'option est reconnue et que les messages de sortie sont corrects
+     * mais n'évalue pas la génération effective des fichiers de test pour éviter les problèmes de compilation
+     */
+    @Test
+    public void testCrudGenerationWithTestsOption() throws Exception {
+        // Configuration du test - générer avec l'option tests
+        String[] args = {"g", "crud", "Product", "--withTests"};
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Vérifications des messages uniquement
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Génération de la structure CRUD complète pour: Product");
+        assertThat(output).contains("Les tests unitaires seront également générés");
+    }
+
+    @Test
+    public void testHelpCommand() {
+        // Configuration du test
+        String[] args = {"help"};
+
+        // Exécution du CLI
+        SpringBootScaffolderCLI.main(args);
+
+        // Vérifications
+        String output = outputCaptor.toString();
+        assertThat(output).contains("Spring Boot Scaffolder CLI - Guide d'utilisation");
+    }
+
+    /**
+     * Utilitaire pour parcourir un dossier récursivement et trouver des fichiers par nom
+     */
+    private List<Path> findGeneratedFiles(Path rootDir, String fileName) throws IOException {
+        return Files.walk(rootDir)
+                .filter(Files::isRegularFile)
+                .filter(path -> path.getFileName().toString().equals(fileName))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Crée une structure minimale d'application Spring Boot pour les tests
+     * Cette structure sera utilisée comme base pour la génération de code
+     */
+    private void createMinimalSpringBootAppStructure(Path rootDir) throws IOException {
+        // Crée les répertoires nécessaires
+        Path srcMainJava = rootDir.resolve("src/main/java");
+        Path srcMainResources = rootDir.resolve("src/main/resources");
+        Path srcTestJava = rootDir.resolve("src/test/java");
+        Path packagePath = srcMainJava.resolve("com/example/demo");
+
+        Files.createDirectories(srcMainJava);
+        Files.createDirectories(srcMainResources);
+        Files.createDirectories(srcTestJava);
+        Files.createDirectories(packagePath);
+
+        // Crée un fichier Application.java minimal
+        Path appFilePath = packagePath.resolve("DemoApplication.java");
+        String appContent = "package com.example.demo;\n\n" +
+                "import org.springframework.boot.SpringApplication;\n" +
+                "import org.springframework.boot.autoconfigure.SpringBootApplication;\n\n" +
+                "@SpringBootApplication\n" +
+                "public class DemoApplication {\n\n" +
+                "    public static void main(String[] args) {\n" +
+                "        SpringApplication.run(DemoApplication.class, args);\n" +
+                "    }\n" +
+                "}\n";
+        Files.writeString(appFilePath, appContent);
+
+        // Crée un fichier application.properties minimal
+        Path propsPath = srcMainResources.resolve("application.properties");
+        String propsContent = "spring.application.name=demo\n";
+        Files.writeString(propsPath, propsContent);
+
+        // Crée un fichier build.gradle minimal
+        Path buildFilePath = rootDir.resolve("build.gradle");
+        String buildContent = "plugins {\n" +
+                "    id 'org.springframework.boot' version '3.2.0'\n" +
+                "    id 'io.spring.dependency-management' version '1.1.4'\n" +
+                "    id 'java'\n" +
+                "}\n\n" +
+                "group = 'com.example'\n" +
+                "version = '0.0.1-SNAPSHOT'\n" +
+                "sourceCompatibility = '17'\n\n" +
+                "repositories {\n" +
+                "    mavenCentral()\n" +
+                "}\n\n" +
+                "dependencies {\n" +
+                "    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'\n" +
+                "    implementation 'org.springframework.boot:spring-boot-starter-web'\n" +
+                "    implementation 'org.mapstruct:mapstruct:1.6.3'\n" +
+                "    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'\n" +
+                "    compileOnly 'org.projectlombok:lombok'\n" +
+                "    annotationProcessor 'org.projectlombok:lombok'\n" +
+                "}\n";
+        Files.writeString(buildFilePath, buildContent);
+
+        // Ajoute un settings.gradle pour compléter la configuration du projet
+        Path settingsPath = rootDir.resolve("settings.gradle");
+        String settingsContent = "rootProject.name = 'demo'\n";
+        Files.writeString(settingsPath, settingsContent);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the Spring Boot scaffolding tool, including a new service for selective component generation and an improved CLI for interactive and command-based usage. Key changes include the addition of the `EnhancedGeneratorService` for flexible code generation, a revamped CLI with support for CRUD and individual component generation, and a minor update to the `Tools` utility class.

### Code Generation Enhancements:
* **`src/main/java/io/github/grafx1/scaffolder/EnhancedGeneratorService.java`:** Added `EnhancedGeneratorService` to support selective generation of Spring Boot components (e.g., entities, DTOs, repositories, services, controllers, mappers) with configurable output directories. This service also includes methods for generating unit tests and handling templates.

### CLI Improvements:
* **`src/main/java/io/github/grafx1/scaffolder/cli/SpringBootScaffolderCLI.java`:** Implemented an enhanced CLI with interactive mode and support for commands like `generate` (or `g`) for CRUD structures or individual components. The CLI provides aliases for component types and supports optional unit test generation.

### Utility Updates:
* **`src/main/java/io/github/grafx1/scaffolder/utils/Tools.java`:** Added a new constant `YELLOW` for yellow-colored output in the CLI.